### PR TITLE
Set PHP's user_agent if empty

### DIFF
--- a/ProcessWireUpgrade.module
+++ b/ProcessWireUpgrade.module
@@ -98,7 +98,9 @@ class ProcessWireUpgrade extends Process {
 	public function init() {
 		if($this->config->demo) throw new WireException("This module cannot be used in demo mode"); 
 		if(!$this->user->isSuperuser()) throw new WireException("This module requires superuser"); 
-		set_time_limit(3600); 
+		$ua = ini_get("user_agent");
+		if(empty($ua)) ini_set("user_agent", "PHP " . PHP_VERSION);
+		set_time_limit(3600);
 		$this->checker = $this->modules->getInstall('ProcessWireUpgradeCheck'); 
 		if(!$this->checker) throw new WireException("Please go to Modules and click 'Check for new modules' - this will auto-update ProcessWireUpgrade."); 
 		parent::init();


### PR DESCRIPTION
Set PHP's user_agent to a non-empty value if not set, as github api requests with an empty/missing user-agent header are rejected with status 403 (forbidden). This should fix issue #11.
