### PR TITLE
Add "include=all" to the parent selector (install)

### DIFF
--- a/ProcessWireUpgrade.module
+++ b/ProcessWireUpgrade.module
@@ -956,7 +956,7 @@ class ProcessWireUpgrade extends Process {
 		$page->name = self::pageName; 
 
 		// installs to the admin "Setup" menu ... change as you see fit
-		$page->parent = $this->pages->get($this->config->adminRootPageID)->child('name=setup');
+		$page->parent = $this->pages->get($this->config->adminRootPageID)->child('include=all, name=setup');
 		$page->process = $this; 
 
 		// we will make the page title the same as our module title


### PR DESCRIPTION
Hi,

I’m including this module in a custom site profile and installing it automatically using finish.php when installing ProcessWire. However the lack of `include=all` in the selector ends up having the module installed under "Admin" instead of "Setup".

This is just a quick fix and best would probably be to convert to the newer way of installing the page, using the process config.

Thanks !